### PR TITLE
fix: Add postgresql to DbService DsnParser

### DIFF
--- a/src/Services/DbService.php
+++ b/src/Services/DbService.php
@@ -43,7 +43,10 @@ class DbService
     public function createDatabase(string $dbName): int
     {
 
-        $dsnParser = new DsnParser(['mysql' => 'pdo_mysql']);
+        $dsnParser = new DsnParser([
+            'mysql' => 'pdo_mysql',
+            'postgresql' => 'pdo_pgsql',
+        ]);
         $tmpConnection = DriverManager::getConnection($dsnParser->parse($this->dbCredentials['db_url']));
 
         $platform = $tmpConnection->getDatabasePlatform();


### PR DESCRIPTION
fix: Add postgresql to DbService DsnParser to fix:

 'The given driver 'postgresql is unknown, Doctrine currently supports only the following drivers: pdo_mysql, pdo_sqlite, pdo_pgsql, pdo_oci, oci8, ibm_db2, pdo_sqlsrv, mysqli, pgsql, sqlsrv, sqlite3'