### PR TITLE
Fix deprecations

### DIFF
--- a/src/DependencyInjection/HakamMultiTenancyExtension.php
+++ b/src/DependencyInjection/HakamMultiTenancyExtension.php
@@ -19,7 +19,7 @@ class HakamMultiTenancyExtension extends Extension implements PrependExtensionIn
     /**
      * @throws \Exception
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
@@ -37,7 +37,7 @@ class HakamMultiTenancyExtension extends Extension implements PrependExtensionIn
         $definition->setArgument(2, $configs['tenant_database_identifier']);
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $configs = $container->getExtensionConfig($this->getAlias());
         $dbSwitcherConfig = $this->processConfiguration(new Configuration(), $configs);


### PR DESCRIPTION
Fix following deprecations since SF7.2

```
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Hakam\MultiTenancyBundle\DependencyInjection\HakamMultiTenancyExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface::prepend()" might add "void" as a native return type declaration in the future. Do the same in implementation "Hakam\MultiTenancyBundle\DependencyInjection\HakamMultiTenancyExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```