### PR TITLE
fix: add missing --dbid and --all options to tenant:database:create command

### DIFF
--- a/src/Command/CreateDatabaseCommand.php
+++ b/src/Command/CreateDatabaseCommand.php
@@ -1,1 +1,113 @@
-<?phpnamespace Hakam\MultiTenancyBundle\Command;use Exception;use Hakam\MultiTenancyBundle\Config\TenantConnectionConfigDTO;use Hakam\MultiTenancyBundle\Enum\DatabaseStatusEnum;use Hakam\MultiTenancyBundle\Exception\MultiTenancyException;use Hakam\MultiTenancyBundle\Port\TenantDatabaseManagerInterface;use Symfony\Component\Console\Attribute\AsCommand;use Symfony\Component\Console\Command\Command;use Symfony\Component\Console\Input\InputInterface;use Symfony\Component\Console\Output\OutputInterface;#[AsCommand(    name: 'tenant:database:create',    description: 'Proxy to create a new tenant database.',)]final class CreateDatabaseCommand extends Command{    use CommandTrait;    public function __construct(        private readonly TenantDatabaseManagerInterface $tenantDatabaseManager)    {        parent::__construct();    }    protected function configure(): void    {        $this            ->setDescription('Create  new databases for a tenant')            ->setAliases(['t:d:c'])            ->setHelp('This command allows you to create the  new database for a tenant which is added to the main database config entity');    }    protected function execute(InputInterface $input, OutputInterface $output): int    {        try {            $listOfNewDbs = $this->tenantDatabaseManager->listMissingDatabases();            if (empty($listOfNewDbs)) {                $output->writeln('No new databases to create');                return 0;            }            foreach ($listOfNewDbs as $newDb) {                $databaseCreated = $this->createDatabase($newDb, $output);                if (!$databaseCreated) {                    throw new MultiTenancyException(sprintf('Failed to create database %s', $newDb->dbname));                }                $output->writeln(sprintf('Database %s created successfully', $newDb->dbname));                $this->tenantDatabaseManager->updateTenantDatabaseStatus($newDb->identifier, DatabaseStatusEnum::DATABASE_CREATED);            }            $output->writeln('The new List of Databases created successfully');            return 0;        } catch (Exception $e) {            $output->writeln($e->getMessage());            return 1;        }    }    private function createDatabase(TenantConnectionConfigDTO $dbConfiguration, OutputInterface $output): bool    {        return $this->tenantDatabaseManager->createTenantDatabase($dbConfiguration);    }}
+<?php
+
+namespace Hakam\MultiTenancyBundle\Command;
+
+use Exception;
+use Hakam\MultiTenancyBundle\Config\TenantConnectionConfigDTO;
+use Hakam\MultiTenancyBundle\Enum\DatabaseStatusEnum;
+use Hakam\MultiTenancyBundle\Exception\MultiTenancyException;
+use Hakam\MultiTenancyBundle\Port\TenantDatabaseManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'tenant:database:create',
+    description: 'Proxy to create a new tenant database.',
+)]
+final class CreateDatabaseCommand extends Command
+{
+    use CommandTrait;
+
+    public function __construct(
+        private readonly TenantDatabaseManagerInterface $tenantDatabaseManager
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Create new databases for a tenant')
+            ->setAliases(['t:d:c'])
+            ->addOption('dbid', 'd', InputOption::VALUE_REQUIRED, 'Create database for a specific tenant ID')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Create all missing databases')
+            ->setHelp('This command allows you to create new databases for tenants. Use --dbid=<id> to create for a specific tenant, or --all to create all missing databases which is added to the main database config entity');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $dbId = $input->getOption('dbid');
+            $all = $input->getOption('all');
+
+            if ($dbId && $all) {
+                $output->writeln('Cannot use --dbid and --all options together');
+                return 1;
+            }
+            if ($dbId) {
+                return $this->createDatabaseById((int) $dbId, $output);
+            }
+            return $this->createAllMissingDatabases($output);
+        } catch (Exception $e) {
+            $output->writeln(sprintf('Failed to create database: %s', $e->getMessage()));
+            return 1;
+        }
+    }
+
+    private function createAllMissingDatabases(OutputInterface $output): int
+    {
+        try {
+            $listOfNewDbs = $this->tenantDatabaseManager->listMissingDatabases();
+            if (empty($listOfNewDbs)) {
+                $output->writeln('No new databases to create');
+                return 0;
+            }
+            foreach ($listOfNewDbs as $newDb) {
+                $databaseCreated = $this->createDatabase($newDb, $output);
+                if (!$databaseCreated) {
+                    throw new MultiTenancyException(sprintf('Failed to create database %s', $newDb->dbname));
+                }
+                $output->writeln(sprintf('Database %s created successfully', $newDb->dbname));
+                $this->tenantDatabaseManager->updateTenantDatabaseStatus($newDb->identifier, DatabaseStatusEnum::DATABASE_CREATED);
+            }
+            $output->writeln('The new List of Databases created successfully');
+            return 0;
+        } catch (Exception $e) {
+            $output->writeln($e->getMessage());
+            return 1;
+        }
+    }
+
+
+    private function createDatabaseById(int $dbId, OutputInterface $output): int
+    {
+        try {
+            $dbConfig = $this->tenantDatabaseManager->getTenantDatabaseById($dbId);
+            if (
+                $dbConfig->dbStatus === DatabaseStatusEnum::DATABASE_CREATED ||
+                $dbConfig->dbStatus === DatabaseStatusEnum::DATABASE_MIGRATED
+            ) {
+                $output->writeln(sprintf('Database %s already exists', $dbConfig->dbname));
+                return 0;
+            }
+            $databaseCreated = $this->createDatabase($dbConfig, $output);
+            if (!$databaseCreated) {
+                throw new MultiTenancyException(sprintf('Failed to create database %s', $dbConfig->dbname, $dbId));
+            }
+            $output->writeln(sprintf('Database %s created successfully for tenant ID %d', $dbConfig->dbname, $dbId));
+            $this->tenantDatabaseManager->updateTenantDatabaseStatus($dbId, DatabaseStatusEnum::DATABASE_CREATED);
+            return 0;
+        } catch (Exception $e) {
+            $output->writeln(sprintf('Failed to create database for tenant ID %d: %s', $dbId, $e->getMessage()));
+            return 1;
+        }
+    }
+
+    private function createDatabase(TenantConnectionConfigDTO $dbConfiguration, OutputInterface $output): bool
+    {
+        return $this->tenantDatabaseManager->createTenantDatabase($dbConfiguration);
+    }
+}

--- a/src/Port/TenantDatabaseManagerInterface.php
+++ b/src/Port/TenantDatabaseManagerInterface.php
@@ -35,6 +35,15 @@ interface TenantDatabaseManagerInterface
      * @return TenantConnectionConfigDTO[] An array of tenant database configurations matching the specified status.
      */
 
+    /**
+     * Get a tenant database configuration by its identifier.
+     *
+     * @param int $identifier The identifier of the tenant database.
+     * @return TenantConnectionConfigDTO The tenant database configuration.
+     * @throws RuntimeException If the tenant database is not found.
+     */
+    public function getTenantDatabaseById(int $identifier): TenantConnectionConfigDTO;
+
     public function getTenantDbListByDatabaseStatus(DatabaseStatusEnum $status): array;
 
     /**
@@ -63,11 +72,11 @@ interface TenantDatabaseManagerInterface
      */
     public function updateTenantDatabaseStatus(int $identifier, DatabaseStatusEnum $status): bool;
 
-//    /**
-//     * Delete a tenant database by its identifier.
-//     *
-//     * @param string $identifier The identifier of the tenant database to delete.
-//     * @return bool True if the database was deleted successfully, false otherwise.
-//     */
-//    public function deleteTenantDatabase(string $identifier): bool;
+    //    /**
+    //     * Delete a tenant database by its identifier.
+    //     *
+    //     * @param string $identifier The identifier of the tenant database to delete.
+    //     * @return bool True if the database was deleted successfully, false otherwise.
+    //     */
+    //    public function deleteTenantDatabase(string $identifier): bool;
 }

--- a/tests/Unit/Adapter/Doctrine/DoctrineTenantDatabaseManagerTest.php
+++ b/tests/Unit/Adapter/Doctrine/DoctrineTenantDatabaseManagerTest.php
@@ -33,11 +33,11 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
 
         // stub getRepository
         $this->em->method('getRepository')
-        ->with(self::ENTITY_CLASS)
-        ->willReturn($this->repo);
+            ->with(self::ENTITY_CLASS)
+            ->willReturn($this->repo);
 
         $this->manager = new DoctrineTenantDatabaseManager(
-        $this->em,
+            $this->em,
             $this->connGen,
             self::ENTITY_CLASS,
             self::IDENTIFIER_FIELD
@@ -47,18 +47,18 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testListDatabasesReturnsDtos(): void
     {
         $entity1 = $this->createConfiguredMock(TenantDbConfigurationInterface::class, [
-        'getId' => 12,
-        'getDriverType' => DriverTypeEnum::MYSQL,
-        'getDbHost' => 'h',
-        'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_MIGRATED,
-        'getDbPort' => 3306,
-        'getDbName' => 'db',
-        'getDbUserName' => 'u',
-        'getDbPassword' => 'p',
-    ]);
+            'getId' => 12,
+            'getDriverType' => DriverTypeEnum::MYSQL,
+            'getDbHost' => 'h',
+            'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_MIGRATED,
+            'getDbPort' => 3306,
+            'getDbName' => 'db',
+            'getDbUserName' => 'u',
+            'getDbPassword' => 'p',
+        ]);
         $this->repo->expects($this->once())
             ->method('findBy')
-        ->willReturn([$entity1]);
+            ->willReturn([$entity1]);
 
         $result = $this->manager->listDatabases();
         $this->assertCount(1, $result);
@@ -70,7 +70,7 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testListDatabasesThrowsIfEmpty(): void
     {
         $this->repo->method('findBy')
-        ->willReturn([]);
+            ->willReturn([]);
         $this->expectException(RuntimeException::class);
         $this->manager->listDatabases();
     }
@@ -78,17 +78,17 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testListMissingDatabasesReturnsDtos(): void
     {
         $entity = $this->createConfiguredMock(TenantDbConfigurationInterface::class, [
-        'getId' => 11,
-        'getDriverType' => DriverTypeEnum::MYSQL,
-        'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_NOT_CREATED,
-        'getDbHost' => 'h',
-        'getDbPort' => 3306,
-        'getDbName' => 'db',
-        'getDbUserName' => 'u',
-        'getDbPassword' => 'p',
-    ]);
+            'getId' => 11,
+            'getDriverType' => DriverTypeEnum::MYSQL,
+            'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_NOT_CREATED,
+            'getDbHost' => 'h',
+            'getDbPort' => 3306,
+            'getDbName' => 'db',
+            'getDbUserName' => 'u',
+            'getDbPassword' => 'p',
+        ]);
         $this->repo->method('findBy')
-        ->willReturn([$entity]);
+            ->willReturn([$entity]);
         $result = $this->manager->listMissingDatabases();
         $this->assertCount(1, $result);
         $this->assertSame(11, $result[0]->identifier);
@@ -97,7 +97,7 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testListMissingDatabasesThrowsIfEmpty(): void
     {
         $this->repo->method('findBy')
-        ->willReturn([]);
+            ->willReturn([]);
         $this->expectException(RuntimeException::class);
         $this->manager->listMissingDatabases();
     }
@@ -105,18 +105,18 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testGetDefaultTenantIDatabaseReturnsDto(): void
     {
         $entity = $this->createConfiguredMock(TenantDbConfigurationInterface::class, [
-        'getId' => 13,
-        'getDriverType' => DriverTypeEnum::MYSQL,
-        'getDbHost' => 'h',
-        'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_CREATED,
-        'getDbPort' => 3306,
-        'getDbName' => 'db',
-        'getDbUserName' => 'u',
-        'getDbPassword' => 'p',
-    ]);
+            'getId' => 13,
+            'getDriverType' => DriverTypeEnum::MYSQL,
+            'getDbHost' => 'h',
+            'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_CREATED,
+            'getDbPort' => 3306,
+            'getDbName' => 'db',
+            'getDbUserName' => 'u',
+            'getDbPassword' => 'p',
+        ]);
         $this->repo->method('findOneBy')
-        ->with(['databaseStatus' => DatabaseStatusEnum::DATABASE_CREATED])
-        ->willReturn($entity);
+            ->with(['databaseStatus' => DatabaseStatusEnum::DATABASE_CREATED])
+            ->willReturn($entity);
         $dto = $this->manager->getDefaultTenantIDatabase();
         $this->assertSame(13, $dto->identifier);
     }
@@ -124,7 +124,7 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testGetDefaultTenantIDatabaseThrowsIfNone(): void
     {
         $this->repo->method('findOneBy')
-        ->willReturn(null);
+            ->willReturn(null);
         $this->expectException(RuntimeException::class);
         $this->manager->getDefaultTenantIDatabase();
     }
@@ -132,17 +132,17 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     public function testCreateTenantDatabaseWrapsExceptions(): void
     {
         $dto = TenantConnectionConfigDTO::fromArgs(
-        identifier : 14,
-        driver: DriverTypeEnum::MYSQL,
-        dbStatus: DatabaseStatusEnum::DATABASE_NOT_CREATED,
-        host: 'h',
-        port : 3306,
-        dbname : 'db',
-        user : 'u',
-        password : 'p',
-    );
+            identifier: 14,
+            driver: DriverTypeEnum::MYSQL,
+            dbStatus: DatabaseStatusEnum::DATABASE_NOT_CREATED,
+            host: 'h',
+            port: 3306,
+            dbname: 'db',
+            user: 'u',
+            password: 'p',
+        );
         $this->connGen->method('generateMaintenanceConnection')
-        ->willThrowException(new Exception('err'));
+            ->willThrowException(new Exception('err'));
         $this->expectException(MultiTenancyException::class);
         $this->manager->createTenantDatabase($dto);
     }
@@ -151,8 +151,8 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
     {
         $entity = $this->createMock(TenantDbConfigurationInterface::class);
         $this->repo->method('findOneBy')
-        ->with([self::IDENTIFIER_FIELD => 130])
-        ->willReturn($entity);
+            ->with([self::IDENTIFIER_FIELD => 130])
+            ->willReturn($entity);
         $this->em->expects($this->once())->method('persist')->with($entity);
         $this->em->expects($this->once())->method('flush');
         $result = $this->manager->updateTenantDatabaseStatus(130, DatabaseStatusEnum::DATABASE_CREATED);
@@ -164,5 +164,43 @@ class DoctrineTenantDatabaseManagerTest extends TestCase
         $this->repo->method('findOneBy')->willReturn(null);
         $this->expectException(RuntimeException::class);
         $this->manager->updateTenantDatabaseStatus(10, DatabaseStatusEnum::DATABASE_CREATED);
+    }
+
+    public function testGetTenantDatabaseByIdReturnsDto(): void
+    {
+        $entity = $this->createConfiguredMock(TenantDbConfigurationInterface::class, [
+            'getId' => 42,
+            'getDriverType' => DriverTypeEnum::MYSQL,
+            'getDbHost' => 'host',
+            'getDatabaseStatus' => DatabaseStatusEnum::DATABASE_NOT_CREATED,
+            'getDbPort' => 3306,
+            'getDbName' => 'tenant_42',
+            'getDbUserName' => 'user',
+            'getDbPassword' => 'pass',
+        ]);
+
+        $this->repo->expects($this->once())
+            ->method('findOneBy')
+            ->with([self::IDENTIFIER_FIELD => 42])
+            ->willReturn($entity);
+
+        $result = $this->manager->getTenantDatabaseById(42);
+
+        $this->assertSame(42, $result->identifier);
+        $this->assertSame('tenant_42', $result->dbname);
+        $this->assertSame(DatabaseStatusEnum::DATABASE_NOT_CREATED, $result->dbStatus);
+    }
+
+    public function testGetTenantDatabaseByIdThrowsIfNotFound(): void
+    {
+        $this->repo->expects($this->once())
+            ->method('findOneBy')
+            ->with([self::IDENTIFIER_FIELD => 999])
+            ->willReturn(null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Tenant database with identifier "999" not found');
+
+        $this->manager->getTenantDatabaseById(999);
     }
 }

--- a/tests/Unit/Command/CreateDatabaseCommandTest.php
+++ b/tests/Unit/Command/CreateDatabaseCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Hakam\MultiTenancyBundle\Tests\Unit\Command;
+
+use Hakam\MultiTenancyBundle\Command\CreateDatabaseCommand;
+use Hakam\MultiTenancyBundle\Config\TenantConnectionConfigDTO;
+use Hakam\MultiTenancyBundle\Enum\DatabaseStatusEnum;
+use Hakam\MultiTenancyBundle\Enum\DriverTypeEnum;
+use Hakam\MultiTenancyBundle\Port\TenantDatabaseManagerInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Exception;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CreateDatabaseCommandTest extends TestCase
+{
+    private TenantDatabaseManagerInterface $mockManager;
+    private CreateDatabaseCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->mockManager = $this->createMock(TenantDatabaseManagerInterface::class);
+        $this->command = new CreateDatabaseCommand($this->mockManager);
+    }
+
+    public function testCreateDatabaseWithDbidOption(): void
+    {
+        $dbConfig = $this->createTenantConfig(5, DatabaseStatusEnum::DATABASE_NOT_CREATED);
+
+        $this->mockManager->expects($this->once())
+            ->method('getTenantDatabaseById')
+            ->with(5)
+            ->willReturn($dbConfig);
+
+        $this->mockManager->expects($this->once())
+            ->method('createTenantDatabase')
+            ->with($dbConfig)
+            ->willReturn(true);
+
+        $this->mockManager->expects($this->once())
+            ->method('updateTenantDatabaseStatus')
+            ->with(5, DatabaseStatusEnum::DATABASE_CREATED);
+
+        $input = new ArrayInput(['--dbid' => '5']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(0, $result);
+        $this->assertStringContainsString('Database tenant_5 created successfully for tenant ID 5', $output->fetch());
+    }
+
+    public function testCreateDatabaseWithDbidOptionWhenAlreadyExists(): void
+    {
+        $dbConfig = $this->createTenantConfig(5, DatabaseStatusEnum::DATABASE_CREATED);
+
+        $this->mockManager->expects($this->once())
+            ->method('getTenantDatabaseById')
+            ->with(5)
+            ->willReturn($dbConfig);
+
+        $this->mockManager->expects($this->never())
+            ->method('createTenantDatabase');
+
+        $input = new ArrayInput(['--dbid' => '5']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(0, $result);
+        $this->assertStringContainsString('Database tenant_5 already exists', $output->fetch());
+    }
+
+    public function testCreateDatabaseWithDbidOptionWhenTenantNotFound(): void
+    {
+        $this->mockManager->expects($this->once())
+            ->method('getTenantDatabaseById')
+            ->with(999)
+            ->willThrowException(new RuntimeException('Tenant database with identifier "999" not found'));
+
+        $input = new ArrayInput(['--dbid' => '999']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('Failed to create database for tenant ID 999', $output->fetch());
+    }
+
+    public function testCreateDatabaseWithAllOption(): void
+    {
+        $dbConfigs = [
+            $this->createTenantConfig(1, DatabaseStatusEnum::DATABASE_NOT_CREATED),
+            $this->createTenantConfig(2, DatabaseStatusEnum::DATABASE_NOT_CREATED),
+        ];
+
+        $this->mockManager->expects($this->once())
+            ->method('listMissingDatabases')
+            ->willReturn($dbConfigs);
+
+        $this->mockManager->expects($this->exactly(2))
+            ->method('createTenantDatabase')
+            ->willReturn(true);
+
+        $this->mockManager->expects($this->exactly(2))
+            ->method('updateTenantDatabaseStatus');
+
+        $input = new ArrayInput(['--all' => true]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(0, $result);
+        $outputContent = $output->fetch();
+        $this->assertStringContainsString('Database tenant_1 created successfully', $outputContent);
+        $this->assertStringContainsString('Database tenant_2 created successfully', $outputContent);
+    }
+
+    public function testCreateDatabaseWithAllOptionWhenNoDatabasesToCreate(): void
+    {
+        $this->mockManager->expects($this->once())
+            ->method('listMissingDatabases')
+            ->willReturn([]);
+
+        $input = new ArrayInput(['--all' => true]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(0, $result);
+        $this->assertStringContainsString('No new databases to create', $output->fetch());
+    }
+
+    public function testCreateDatabaseWithBothDbidAndAllOptionsThrowsError(): void
+    {
+        $input = new ArrayInput(['--dbid' => '5', '--all' => true]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('Cannot use --dbid and --all options together', $output->fetch());
+    }
+
+    public function testCreateDatabaseWithoutOptionsUsesBackwardCompatibleBehavior(): void
+    {
+        $dbConfigs = [$this->createTenantConfig(1, DatabaseStatusEnum::DATABASE_NOT_CREATED)];
+
+        $this->mockManager->expects($this->once())
+            ->method('listMissingDatabases')
+            ->willReturn($dbConfigs);
+
+        $this->mockManager->expects($this->once())
+            ->method('createTenantDatabase')
+            ->willReturn(true);
+
+        $input = new ArrayInput([]);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(0, $result);
+        $this->assertStringContainsString('Database tenant_1 created successfully', $output->fetch());
+    }
+
+    public function testCreateDatabaseFailureWithDbidOption(): void
+    {
+        $dbConfig = $this->createTenantConfig(5, DatabaseStatusEnum::DATABASE_NOT_CREATED);
+
+        $this->mockManager->expects($this->once())
+            ->method('getTenantDatabaseById')
+            ->willReturn($dbConfig);
+
+        $this->mockManager->expects($this->once())
+            ->method('createTenantDatabase')
+            ->willReturn(false);
+
+        $input = new ArrayInput(['--dbid' => '5']);
+        $output = new BufferedOutput();
+
+        $result = $this->command->run($input, $output);
+
+        $this->assertEquals(1, $result);
+        $this->assertStringContainsString('Failed to create database', $output->fetch());
+    }
+
+    private function createTenantConfig(int $id, DatabaseStatusEnum $status): TenantConnectionConfigDTO
+    {
+        return TenantConnectionConfigDTO::fromArgs(
+            identifier: $id,
+            driver: DriverTypeEnum::MYSQL,
+            dbStatus: $status,
+            host: 'localhost',
+            port: 3306,
+            dbname: "tenant_{$id}",
+            user: 'user',
+            password: 'password'
+        );
+    }
+}


### PR DESCRIPTION
Hi! I’m using your bundle in a project and noticed the ‎`--dbid` option wasn’t working as expected (as mentioned in issue #62). Since I ran into the same problem, I wanted to help out and put together this pull request to fix it for everyone. 

Thanks a lot for your work on this bundle, let me know if you have any feedback or if there’s anything I should adjust! 😁

## Changes
- Added missing `--dbid` and `--all` options to the command
- Implemented `getTenantDatabaseById` method in the interface and manager
- Added comprehensive tests for the new functionality
- Maintained backward compatibility

## Usage
```bash
# Now works as documented:
php bin/console tenant:database:create --dbid=5
php bin/console tenant:database:create --all
```

Fix bug described in #62