### PR TITLE
Fix identity map error when SwitchDbEvent is dispatched twice for the…

### DIFF
--- a/src/EventListener/DbSwitchEventListener.php
+++ b/src/EventListener/DbSwitchEventListener.php
@@ -36,6 +36,12 @@ class DbSwitchEventListener implements EventSubscriberInterface
         $tenantDbConfigDTO = $this->tenantConfigProvider->getTenantConnectionConfig($switchDbEvent->getDbIndex());
         $tenantConnection = $this->container->get('doctrine')->getConnection('tenant');
 
+        // Skip if already connected to the same tenant database
+        $currentParams = $tenantConnection->getParams();
+        if (isset($currentParams['dbname']) && $currentParams['dbname'] === $tenantDbConfigDTO->dbname) {
+            return;
+        }
+
         $params = [
             'dbname' => $tenantDbConfigDTO->dbname,
             'user' => $tenantDbConfigDTO->user ?? $this->parseDatabaseUrl($this->databaseURL)['user'],


### PR DESCRIPTION
This pull request improves the tenant database switching logic in the `DbSwitchEventListener` by preventing unnecessary reconnections when already connected to the correct tenant database. It also adds a dedicated unit test to verify this behavior.

Enhancements to database switching logic:

* Updated `DbSwitchEventListener` to check if the current database connection is already using the target tenant database, and to skip switching if so. This prevents redundant reconnections and potential side effects.